### PR TITLE
Add FishNet networking folder and client start enabler

### DIFF
--- a/Networking/FishNet/EnableOnClientStart.cs
+++ b/Networking/FishNet/EnableOnClientStart.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using FishNet.Object;
+using UnityEngine;
+
+/// <summary>
+/// Enables configured objects and components when the local client starts.
+/// </summary>
+public class EnableOnClientStart : NetworkBehaviour
+{
+    [Tooltip("GameObjects to enable on client start")]
+    public List<GameObject> objectsToEnable = new List<GameObject>();
+
+    [Tooltip("Components to enable on client start")]
+    public List<MonoBehaviour> componentsToEnable = new List<MonoBehaviour>();
+
+    /// <summary>
+    /// Called when the local client begins.
+    /// </summary>
+    public override void OnStartClient()
+    {
+        base.OnStartClient();
+
+        foreach (GameObject obj in objectsToEnable)
+        {
+            if (obj != null)
+                obj.SetActive(true);
+        }
+
+        foreach (MonoBehaviour mb in componentsToEnable)
+        {
+            if (mb != null)
+                mb.enabled = true;
+        }
+    }
+}

--- a/Networking/FishNet/README.md
+++ b/Networking/FishNet/README.md
@@ -1,0 +1,6 @@
+# FishNet Networking
+
+Scripts in this folder use the [FishNet](https://github.com/FirstGearGames/FishNet) library.
+
+## Components
+- `EnableOnClientStart` - Enables configured objects and components when a client connects.

--- a/Networking/README.md
+++ b/Networking/README.md
@@ -1,0 +1,3 @@
+# Networking
+
+This directory collects scripts for adding multiplayer functionality to your game. The `FishNet` subfolder contains components built for the FishNet networking library.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This repository collects small Unity scripts that can be easily integrated into 
 ## Essential Scripts
 The `EssentialScripts` folder contains quick-drop components for common tasks like audio volume control and scene loading.
 
+## Networking
+Scripts related to multiplayer features live in the `Networking` folder. The `FishNet` subfolder includes components specifically for the FishNet networking library.
+
 ## Usage
 1. Download the individual scripts you want from this repository.
 2. Drop the scripts into your Unity project's **Assets** folder.


### PR DESCRIPTION
## Summary
- document upcoming networking folder in repo overview
- add Networking folder with FishNet readmes
- add `EnableOnClientStart` component to turn on objects and components when a client joins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841b7f99db4832abe626e5198030f38